### PR TITLE
Update przekrety.txt

### DIFF
--- a/sections/przekrety.txt
+++ b/sections/przekrety.txt
@@ -13427,3 +13427,4 @@
 ||*.hekko24.pl/weryfikacja/$all
 ||*.kei.pl/weryfikacja/$all
 ||*.*.mirsolar.com.tr^$all
+||biegnij.buzz^$all


### PR DESCRIPTION
Przekręt na pozyskiwanie danych potencjalnych ofiar. Nieuprawnione wykorzystanie marki Decathlon. 
"Decathlon nie sponsoruje, ani nie jest związane z Global Data Leads LLC lub tym serwisem"