### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.txt linguist-language=AdBlock
+templates/*.template linguist-language=AdBlock

--- a/sections/.gitattributes
+++ b/sections/.gitattributes
@@ -1,1 +1,0 @@
-*.txt linguist-language=AdBlock


### PR DESCRIPTION
Override Linguist config, see https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes

Fix previous PR (handle `templates` and `KAD.txt`). 

Since grammar detection takes place in a low priority process, it is possible that the highlight fluctuates for a while.

@krystian3w 